### PR TITLE
Add support for `access_type` and `prompt`

### DIFF
--- a/lib/omniauth/strategies/zoho.rb
+++ b/lib/omniauth/strategies/zoho.rb
@@ -11,7 +11,7 @@ module OmniAuth
       }
 
       option provider_ignores_state: true
-      option :authorize_options, %i[access_type prompt]
+      option :authorize_options, %i[access_type prompt scope]
 
       def authorize_params
         super.tap do |params|

--- a/lib/omniauth/strategies/zoho.rb
+++ b/lib/omniauth/strategies/zoho.rb
@@ -11,6 +11,17 @@ module OmniAuth
       }
 
       option provider_ignores_state: true
+      option :authorize_options, %i[access_type prompt]
+
+      def authorize_params
+        super.tap do |params|
+          options[:authorize_options].each do |k|
+            params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
+          end
+
+          params[:access_type] = 'offline' if params[:access_type].nil?
+        end
+      end
 
       uid{ raw_info['id'] }
 

--- a/lib/omniauth/zoho/version.rb
+++ b/lib/omniauth/zoho/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Zoho
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
The Zoho API won't return any `refresh_token` unless the `access_type` option in the provider is set as `offline` (as stated in the [documentation](https://www.zoho.com/projects/help/rest-api/get-tickets-api.html#authorize)).

The current version of the Gem does not support this option, as well as the `prompt` option that is supposed to provide a new `refresh_token` every time an user re-authenticates. This is problematic for a server-side use case.

This PR is there to add the support for these two options (inspired from [omniauth-google-oauth2](https://github.com/zquestz/omniauth-google-oauth2/blob/df5e09a5e0b9f18caac39efb0023eccab966a0e7/lib/omniauth/strategies/google_oauth2.rb#L30-L42)).